### PR TITLE
Geoserver support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ type PointSeries = Point[];
 The component currently accepts the following props (props with question marks are optional):
 
 - geoserver?: Boolean value to enable geoserver support. Default is false and will use an object with url and attribution properties for the tile layer if you're familiar with leaflet (Defaults to OpenStreetMap settings). When enabled, provide the following props:
--geoPort: String. The port on which local geoserver is running.
--geoWorkspace: String. The workspace in which the maps layers are stored on geoserver.
--geoLayer: String. The map layer from the workspace that is to be used.
+  - geoPort: String. The port on which local geoserver is running.
+  - geoWorkspace: String. The workspace in which the maps layers are stored on geoserver.
+  - geoLayer: String. The map layer from the workspace that is to be used.
 - mapStyle?: Object. You can pass this prop as an object that contains any properties you could give to html element. If defining yourself you MUST pass it a fixed height property or the component will not display. Default { height: 300, width: "auto" }
 - bindMap?: Boolean. Allows you to set whether the map should be bound to the area of the globe. Default true.
 - startPort?: "auto" | "default" | Viewport. Where the map should set its initial viewport. "default" starts zoomed out viewing the whole globe. "auto" creates a view zoomed in on all the map entities provided i.e. points, circles etc. You can also pass in your own viewport and it will use that. Default "default".

--- a/README.md
+++ b/README.md
@@ -41,9 +41,8 @@ type PointSeries = Point[];
 The component currently accepts the following props (props with question marks are optional):
 
 - geoserver?: Boolean value to enable geoserver support. Default is false and will use an object with url and attribution properties for the tile layer if you're familiar with leaflet (Defaults to OpenStreetMap settings). When enabled, provide the following props:
-  - geoPort: String. The port on which local geoserver is running.
-  - geoWorkspace: String. The workspace in which the maps layers are stored on geoserver.
-  - geoLayer: String. The map layer from the workspace that is to be used.
+  - geoURL: String. The URL on which local geoserver is running.
+  - geoLayer: String. The map layer from the Geoserver workspace that is to be used.
 - mapStyle?: Object. You can pass this prop as an object that contains any properties you could give to html element. If defining yourself you MUST pass it a fixed height property or the component will not display. Default { height: 300, width: "auto" }
 - bindMap?: Boolean. Allows you to set whether the map should be bound to the area of the globe. Default true.
 - startPort?: "auto" | "default" | Viewport. Where the map should set its initial viewport. "default" starts zoomed out viewing the whole globe. "auto" creates a view zoomed in on all the map entities provided i.e. points, circles etc. You can also pass in your own viewport and it will use that. Default "default".
@@ -74,7 +73,10 @@ import React from "react";
 import LocationPicker from "react-leaflet-location-picker";
 
 const MyComponent = () => {
-  const pointVals = [[50, 2], [45, -10]];
+  const pointVals = [
+    [50, 2],
+    [45, -10]
+  ];
   const pointMode = {
     banner: true,
     control: {

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ type PointSeries = Point[];
 The component currently accepts the following props (props with question marks are optional):
 
 - geoserver?: Boolean value to enable geoserver support. Default is false and will use an object with url and attribution properties for the tile layer if you're familiar with leaflet (Defaults to OpenStreetMap settings). When enabled, provide the following props:
-    -geoPort: String. The port on which local geoserver is running.
-    -geoWorkspace: String. The workspace in which the maps layers are stored on geoserver.
-    -geoLayer: String. The map layer from the workspace that is to be used.
+-geoPort: String. The port on which local geoserver is running.
+-geoWorkspace: String. The workspace in which the maps layers are stored on geoserver.
+-geoLayer: String. The map layer from the workspace that is to be used.
 - mapStyle?: Object. You can pass this prop as an object that contains any properties you could give to html element. If defining yourself you MUST pass it a fixed height property or the component will not display. Default { height: 300, width: "auto" }
 - bindMap?: Boolean. Allows you to set whether the map should be bound to the area of the globe. Default true.
 - startPort?: "auto" | "default" | Viewport. Where the map should set its initial viewport. "default" starts zoomed out viewing the whole globe. "auto" creates a view zoomed in on all the map entities provided i.e. points, circles etc. You can also pass in your own viewport and it will use that. Default "default".

--- a/README.md
+++ b/README.md
@@ -40,7 +40,10 @@ type PointSeries = Point[];
 
 The component currently accepts the following props (props with question marks are optional):
 
-- tileLayer?: An object with url and attribution properties for the tile layer if you're familiar with leaflet. Defaults to OpenStreetMap settings.
+- geoserver?: Boolean value to enable geoserver support. Default is false and will use an object with url and attribution properties for the tile layer if you're familiar with leaflet (Defaults to OpenStreetMap settings). When enabled, provide the following props:
+    -geoPort: String. The port on which local geoserver is running.
+    -geoWorkspace: String. The workspace in which the maps layers are stored on geoserver.
+    -geoLayer: String. The map layer from the workspace that is to be used.
 - mapStyle?: Object. You can pass this prop as an object that contains any properties you could give to html element. If defining yourself you MUST pass it a fixed height property or the component will not display. Default { height: 300, width: "auto" }
 - bindMap?: Boolean. Allows you to set whether the map should be bound to the area of the globe. Default true.
 - startPort?: "auto" | "default" | Viewport. Where the map should set its initial viewport. "default" starts zoomed out viewing the whole globe. "auto" creates a view zoomed in on all the map entities provided i.e. points, circles etc. You can also pass in your own viewport and it will use that. Default "default".

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-location-picker",
-  "version": "1.3.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-location-picker",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "A flexible component for picking points or areas from react-leaflet.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/LocationPicker.tsx
+++ b/src/LocationPicker.tsx
@@ -26,8 +26,7 @@ export type IViewport = { center: [number, number]; zoom: number };
 export type ILocationPickerProps = Readonly<typeof defaultProps>;
 const defaultProps = {
   geoserver: false,
-  geoPort: "",
-  geoWorkspace: "",
+  geoURL: "",
   geoLayer: "",
   mapStyle: { height: 300, width: "auto" } as React.CSSProperties,
   bindMap: true,
@@ -183,21 +182,21 @@ export default class LocationPicker extends Component<
     }
   };
   private renderTileLayer = () => {
-    const { geoserver, geoLayer, geoPort, geoWorkspace } = this.props;
-    const tileLayer = geoserver
-      ? {
-          url: `http://localhost:${geoPort}/geoserver/${geoWorkspace}/wms?`,
-          layers: geoLayer,
-          attribution: "Geoserver"
-        }
-      : {
-          url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
-          layers: "",
-          attribution:
-            '&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
-        };
+    const { geoserver, geoURL, geoLayer } = this.props;
+    const tileLayer = {
+      url: "https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png",
+      layers: "",
+      attribution:
+        '&amp;copy <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
+    };
     if (geoserver) {
-      return <WMSTileLayer {...tileLayer} />;
+      return (
+        <WMSTileLayer
+          url={geoURL}
+          layers={geoLayer}
+          attribution={"Geoserver"}
+        />
+      );
     } else {
       return <TileLayer {...tileLayer} />;
     }


### PR DESCRIPTION
Provides new props to switch to a locally running geoserver instance. Makes use of WMSTilelayer wrapper from react-leaflet. Default is still Opes Street Maps. 

Upcoming changes may come.